### PR TITLE
Adding a Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.12.0-alpine as build
+ENV NAME oamctl
+# Build oamctl
+RUN apk add git alpine-sdk upx \
+ && git clone https://github.com/oam-dev/oamctl.git ${NAME} \
+ && cd ${NAME} \
+ && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -ldflags='-w -s -extldflags "-static"' -o /go/bin/${NAME}\
+ && upx --brute /go/bin/${NAME}
+
+FROM busybox:latest
+COPY --from=build /go/bin/${NAME} /${NAME}
+ENTRYPOINT [ "/oamctl" ]


### PR DESCRIPTION
Hi,
As an intern in Microsoft, I'm currently working with the Open Application Model, Dapr, and of course oamctl.
While using oamctl, I've encountered some issues, namely with the Go version required, that is a bit on the older side, and conflicting with the Go version required by Dapr for example. 
To address these issues, I've made a small Dockerfile that I'm currently using to run oamctl.
I thought it would be good to share it with the community, as people interested in OAM/oamctl would probably be accustomed to Docker.

Thanks to multistage building and upx, the whole image is only about 8MB. It is however pretty long to build, and it would maybe be better to host the image on the Docker Hub. 